### PR TITLE
Sample with lexer src pos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Run in the root directory of the project
 raco pkg install
 ```
 
-After that we will be able to use
+After that you will be able to use
 ```
 #lang my-lang
 ```

--- a/lexer.rkt
+++ b/lexer.rkt
@@ -1,4 +1,4 @@
-#lang racket
+#lang racket/base
 
 (require parser-tools/lex)
 
@@ -12,7 +12,7 @@
 ; (custom-lexer in) -> returns 'LPAREN
 ; (custom-lexer in) -> returns (token 'NUM 1)
 (define custom-lexer
-    (lexer
+    (lexer-src-pos
       [(eof) (token-EOF)]
       ["(" (token-LPAREN)]
       [")" (token-RPAREN)]
@@ -20,6 +20,8 @@
       ["-" (token-SUBTRACT)]
       [(repetition 1 +inf.0 numeric) (token-NUM (string->number lexeme))]
       ; invoke the lexer again to skip the current token
-      [whitespace (custom-lexer input-port)]))
+      ; the return-without-pos call is needed to avoid a "double" wrapping into a position token
+      ; ref. https://github.com/racket/parser-tools/blob/b08f6137a3c067720c4b4723dd726652af288e97/parser-tools-lib/parser-tools/yacc.rkt#L247
+      [whitespace (return-without-pos (custom-lexer input-port))]))
 
 (provide custom-lexer basic-tokens punct-tokens)

--- a/main.rkt
+++ b/main.rkt
@@ -5,7 +5,7 @@
  
   (provide (rename-out [my-read read]
                        [my-read-syntax read-syntax]))
- 
+
   (define (my-read in)
     (syntax->datum
      (my-read-syntax #f in)))
@@ -14,4 +14,6 @@
     (with-syntax ([result (the-parser (lambda () (custom-lexer in)))])
       (strip-context
        #'(module anything racket
+           (define subtract -)
+           (define add +)
            result)))))

--- a/parser.rkt
+++ b/parser.rkt
@@ -1,21 +1,40 @@
-#lang racket
+#lang racket/base
 
 (require parser-tools/yacc
+         parser-tools/lex
          "lexer.rkt")
 
 
+; (struct srcloc (source line column position span))
+(define (positions->srcloc start-pos end-pos)
+  (srcloc #f
+          (position-line start-pos)
+          (position-col start-pos)
+          (position-offset start-pos)
+          (- (position-offset end-pos) (position-offset start-pos))))
+
+; docs for datum->syntax
+; https://docs.racket-lang.org/reference/stxops.html#%28def._%28%28quote._~23~25kernel%29._datum-~3esyntax%29%29
+(define (position-token->syntax val start-pos end-pos)
+  (datum->syntax #f val (positions->srcloc start-pos end-pos)))
+
 (define the-parser
-    (parser
-      [start expr]
-      [end EOF]
-      [error void]
-      [tokens basic-tokens punct-tokens]
-      [precs (left SUBTRACT ADD)]
-      [grammar
-       [expr [(LPAREN expr RPAREN) $2]
-             [(NUM) $1]
-             [(expr SUBTRACT expr) (- $1 $3)]
-             [(expr ADD expr) (+ $1 $3)]]
-       ]))
+  (parser
+   [start expr]
+   [end EOF]
+   [error void]
+   [src-pos]
+   [tokens basic-tokens punct-tokens]
+   [precs (left SUBTRACT ADD)]
+   [grammar
+          ; the start position of a parenthesized expression is the start position of the open '('
+    [expr [(LPAREN expr RPAREN) (position-token->syntax $2 $1-start-pos $3-end-pos)] 
+          ; the start position of a number is the start position of the number token
+          [(NUM) (position-token->syntax $1 $1-start-pos $1-end-pos)]
+          ; the start position of a subtract expression is the start position of the first expression
+          [(expr SUBTRACT expr) (position-token->syntax `(subtract ,$1 ,$3) $1-start-pos $3-end-pos)]
+          ; the start position of an add expression is the start position of the first expression 
+          [(expr ADD expr) (position-token->syntax `(add ,$1 ,$3) $1-start-pos $3-end-pos)]]
+    ]))
 
 (provide the-parser)

--- a/test.rkt
+++ b/test.rkt
@@ -7,10 +7,10 @@
   (test-case
    "Tokens are recognized correctly"
    (let* ([in (open-input-string "()+- 123")])
-     (check-eqv? (custom-lexer in) 'LPAREN)
-     (check-eqv? (custom-lexer in) 'RPAREN)
-     (check-eqv? (custom-lexer in) 'ADD)
-     (check-eqv? (custom-lexer in) 'SUBTRACT)
+     (check-eqv? (position-token-token (custom-lexer in)) 'LPAREN)
+     (check-eqv? (position-token-token (custom-lexer in)) 'RPAREN)
+     (check-eqv? (position-token-token (custom-lexer in)) 'ADD)
+     (check-eqv? (position-token-token (custom-lexer in)) 'SUBTRACT)
      (let ([t (custom-lexer in)])
-      (check-eqv? (token-name t) 'NUM)
-      (check-eqv? (token-value t) 123)))))
+      (check-eqv? (token-name (position-token-token t)) 'NUM)
+      (check-eqv? (token-value (position-token-token t)) 123)))))


### PR DESCRIPTION
The `parser` now returns a syntax object instead of the computed value of the expression. I think this is more in line with what an actual parser would do, return a syntax tree and not the result of the evaluation.